### PR TITLE
Refine exception handling in delete message test

### DIFF
--- a/src/RazorPages/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/RazorPages/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -105,7 +105,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
             {
                 await db.DeleteMessageAsync(recId);
             }
-            catch
+            catch (DbUpdateConcurrencyException)
             {
                 // recId doesn't exist
             }


### PR DESCRIPTION
Updated the `DeleteMessageAsync_NoMessageIsDeleted_WhenMessageIsNotFound` test method to catch `DbUpdateConcurrencyException` specifically, improving clarity and precision in handling cases where a record ID does not exist.